### PR TITLE
Add option to pass configuration file as a CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ socket_timeout=120000
 # proxy_pwd=secret  
 ``` 
 
+A configuration file in another location can be specified by the `--config-file` option. It is even possible to split the configuration into two or more files. This is useful, for example, to keep server configuration in one file and dataset configuration in another:
+```  
+./motuclient.py --config-file ~/server.ini --config-file ~/mercator.ini
+``` 
+If by chance there is a parameter listed in both configuration files, the value in the last file (e.g. `mercator.ini`) is the one actually used.
 
 # <a name="Usage">Usage</a>  
 Starts the motu python client.  

--- a/src/python/motuclient.py
+++ b/src/python/motuclient.py
@@ -97,10 +97,6 @@ def load_options():
     # create option parser
     parser = optparse.OptionParser(version=get_client_artefact() + ' v' + get_client_version())
 
-    # create config parser
-    conf_parser = ConfigParser.ConfigParser()
-    conf_parser.read(os.path.expanduser(CFG_FILE))
-
     # add available options
     parser.add_option( '--quiet', '-q',
                        help = "prevent any output in stdout",
@@ -231,6 +227,23 @@ def load_options():
                        action='store_true',
                        dest='console_mode')
 
+    parser.add_option( '--config-file',
+                       help = f"Path of the optional configuration file [default: {CFG_FILE}]",
+                       action='append',
+                       dest="config_file",
+                       type="string")
+
+    # create config parser
+    conf_parser = ConfigParser.ConfigParser()
+
+    # read configuration file name from cli arguments or use default
+    # cant set default in parser.add_option due to optparse/argparse bug:
+    # https://bugs.python.org/issue16399
+    config_file = parser.parse_args()[0].config_file
+    if config_file is None:
+        config_file = [CFG_FILE]
+    config_file=[os.path.expanduser(x) for x in config_file]
+    conf_parser.read(config_file)
 
     # set default values by picking from the configuration file
     default_values = {}

--- a/src/python/motuclient.py
+++ b/src/python/motuclient.py
@@ -228,7 +228,7 @@ def load_options():
                        dest='console_mode')
 
     parser.add_option( '--config-file',
-                       help = f"Path of the optional configuration file [default: {CFG_FILE}]",
+                       help = "Path of the optional configuration file [default: %s]" % CFG_FILE,
                        action='append',
                        dest="config_file",
                        type="string")


### PR DESCRIPTION
Small change to allow CLI argument `--config-file` to pass configuration file(s) different than the standard location (`~/motuclient/motuclient-python.ini`). The idea came from #13. This even allows two or more configuration files. This way the user can have a single file with only the server configuration (e.g. `user`, `pwd`, `proxy_server`, etc)  and multiple files with diferent datasets configuration (e.g. `service_id`, `product_id`, etc).