### PR TITLE
Cleanly handle CMEMS API interaction failures

### DIFF
--- a/src/python/motu_utils/motu_api.py
+++ b/src/python/motu_utils/motu_api.py
@@ -622,7 +622,6 @@ def execute_request(_options):
                             log.error(motu_reply)
                             dom = None
                             pass
-                            
     
                         if dom:
                             for node in dom.getElementsByTagName('statusModeResponse'):
@@ -662,3 +661,4 @@ def execute_request(_options):
             raise
     finally:
         stopWatch.stop()
+

--- a/src/python/motu_utils/motu_api.py
+++ b/src/python/motu_utils/motu_api.py
@@ -615,12 +615,22 @@ def execute_request(_options):
                         
                         m = utils_http.open_url(requestUrlCas, **url_config)                
                         motu_reply=m.read()
-                        dom = minidom.parseString(motu_reply)
+                        dom = None
+                        try:
+                            dom = minidom.parseString(motu_reply)
+                        except:
+                            log.error(motu_reply)
+                            dom = None
+                            pass
+                            
     
-                        for node in dom.getElementsByTagName('statusModeResponse'):
-                            status = node.getAttribute('status')    
-                            dwurl = node.getAttribute('remoteUri')
-                            msg = node.getAttribute('msg')
+                        if dom:
+                            for node in dom.getElementsByTagName('statusModeResponse'):
+                                status = node.getAttribute('status')    
+                                dwurl = node.getAttribute('remoteUri')
+                                msg = node.getAttribute('msg')
+                        else:
+                            status = 4
                             
                         # Check status
                         if status == "0" or status == "3": # in progress/pending
@@ -631,6 +641,8 @@ def execute_request(_options):
     
                     if status == "2": 
                         log.error(msg) 
+                    if status == "4": 
+                        log.error("CMEMS API interaction appears to have failed - reported as issue CMEMS:11022")
                     if status == "1": 
                         log.info('The product is ready for download')
                         if dwurl != "":


### PR DESCRIPTION
The motuclient fails internally when the CMEMS API response is not as expected.  The server appears to be behaving erratically.  The motuclient should at least handle the error cleanly and report back the error, rather than faulting (independently of the server behaviour).

This has been reported and logged as CMEMS case number 11022.

This pull request fixes the client behaviour (and moreover enables my scientific codes to run successfully).
